### PR TITLE
Missing os import

### DIFF
--- a/budgetdatapackage/datapackage.py
+++ b/budgetdatapackage/datapackage.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import
+
+import os
 import datapackage
 from .resource import BudgetResource
 


### PR DESCRIPTION
Simple fix: `import os` was missing.
